### PR TITLE
Add global default text colors for improved theme typography

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -29,6 +29,7 @@ body {
 }
 
 body {
+    color: var(--color-text-default);
     background:
         radial-gradient(circle at 20% 80%, var(--bg-top-primary) 0%, transparent 50%),
         radial-gradient(circle at 80% 20%, var(--bg-bottom-primary) 0%, transparent 50%),

--- a/src/lib/styles/theme.scss
+++ b/src/lib/styles/theme.scss
@@ -11,6 +11,7 @@
 	--color-error: #ef4444;
 
 	// Light theme text colors
+	--color-text-default: #000000;
 	--color-text-primary: #dcdcdc;
 	--color-text-secondary: #334155;
 	--color-text-muted: #64748b;
@@ -32,6 +33,7 @@
 	--color-warning: #fbbf24;
 	--color-error: #f87171;
 
+	--color-text-default: #ffffff;
 	--color-text-primary: #f1f5f9;
 	--color-text-secondary: #cbd5e1;
 	--color-text-muted: #94a3b8;
@@ -52,6 +54,7 @@
 	--color-warning: #feca57;
 	--color-error: #ff9ff3;
 
+	--color-text-default: #2d3748;
 	--color-text-primary: #2d3748;
 	--color-text-secondary: #4a5568;
 	--color-text-muted: #718096;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,7 +15,7 @@
 	<div>
 		<div>
 			<GlassCard>
-				<h1 class="font-bold text-inverse mb-2 px-2">Test Pages</h1>
+				<h1 class="font-bold mb-2 px-2">Test Pages</h1>
 				<div class="flex flex-col gap-2 p-2">
 					{#each testPages as page}
 						<MrButton
@@ -33,10 +33,10 @@
 		<br />
 		<div class="text-center">
 			<GlassCard>
-				<h1 class="font-bold text-inverse mb-2 px-2">
+				<h1 class="font-bold mb-2 px-2">
 					Do Things<span class="text-warning font-bold">.</span>
 				</h1>
-				<p class="text-inverse font-light mt-0 px-2">
+				<p class="font-light mt-0 px-2">
 					In life<span class="text-warning font-bold">.</span>
 				</p>
 			</GlassCard>

--- a/src/routes/_test/goals-list/+page.svelte
+++ b/src/routes/_test/goals-list/+page.svelte
@@ -64,14 +64,14 @@
 	<div>
 		<div class="flex items-center justify-between mb-4">
 			<MrButton onclick={() => changeDate(-1)}>← Previous Day</MrButton>
-			<span class="text-inverse">
+			<span>
 				{displayDate.toLocaleDateString()} ({getDayNameForDate(displayDate)})
 			</span>
 			<MrButton onclick={() => changeDate(1)}>Next Day →</MrButton>
 		</div>
 
 		{#if currentGoals.length === 0}
-			<span class="text-white">No goals found for this date.</span>
+			<span>No goals found for this date.</span>
 		{:else}
 			<div class="grid gap-2">
 				{#each currentGoals as goal}

--- a/src/routes/_test/mr-showcase/+page.svelte
+++ b/src/routes/_test/mr-showcase/+page.svelte
@@ -54,7 +54,7 @@
 		<h2 class="mb-4">Icon Buttons</h2>
 		{#each variants as variant}
 			<div class="space-y-2">
-				<h3 class="text-white text-lg font-medium capitalize">{variant}</h3>
+				<h3 class=" text-lg font-medium capitalize">{variant}</h3>
 				<div class="flex gap-4 items-center flex-wrap">
 					{#each sizes as size}
 						<MrButton {variant} {size} icon>
@@ -68,11 +68,11 @@
 
 	<!-- Prepend Icon Buttons -->
 	<section>
-		<h2 class="text-white text-2xl font-semibold mb-4">Prepend Icon Buttons</h2>
+		<h2 class=" text-2xl font-semibold mb-4">Prepend Icon Buttons</h2>
 		<div class="space-y-4">
 			{#each variants as variant}
 				<div class="space-y-2">
-					<h3 class="text-white text-lg font-medium capitalize">{variant}</h3>
+					<h3 class=" text-lg font-medium capitalize">{variant}</h3>
 					<div class="flex gap-4 items-center flex-wrap">
 						{#each sizes as size}
 							<MrButton {variant} {size}>
@@ -88,11 +88,11 @@
 
 	<!-- Append Icon Buttons -->
 	<section>
-		<h2 class="text-white text-2xl font-semibold mb-4">Append Icon Buttons</h2>
+		<h2 class=" text-2xl font-semibold mb-4">Append Icon Buttons</h2>
 		<div class="space-y-4">
 			{#each variants as variant}
 				<div class="space-y-2">
-					<h3 class="text-white text-lg font-medium capitalize">{variant}</h3>
+					<h3 class=" text-lg font-medium capitalize">{variant}</h3>
 					<div class="flex gap-4 items-center flex-wrap">
 						{#each sizes as size}
 							<MrButton {variant} {size}>
@@ -108,7 +108,7 @@
 
 	<!-- Disabled States -->
 	<section>
-		<h2 class="text-white text-2xl font-semibold mb-4">Disabled States</h2>
+		<h2 class=" text-2xl font-semibold mb-4">Disabled States</h2>
 		<div class="space-y-4">
 			{#each variants as variant}
 				<div class="flex gap-4 items-center flex-wrap">
@@ -129,11 +129,11 @@
 
 	<!-- Real-world Examples -->
 	<section>
-		<h2 class="text-white text-2xl font-semibold mb-4">Real-world Examples</h2>
+		<h2 class=" text-2xl font-semibold mb-4">Real-world Examples</h2>
 		<div class="space-y-6">
 			<!-- Action buttons -->
 			<div class="space-y-2">
-				<h3 class="text-white text-lg font-medium">Action Buttons</h3>
+				<h3 class=" text-lg font-medium">Action Buttons</h3>
 				<div class="flex gap-4 flex-wrap">
 					<MrButton variant="filled">
 						<MrIcon icon="mdi-plus" class="mr-2" />
@@ -154,7 +154,7 @@
 
 			<!-- Icon only buttons -->
 			<div class="space-y-2">
-				<h3 class="text-white text-lg font-medium">Icon Only Buttons</h3>
+				<h3 class=" text-lg font-medium">Icon Only Buttons</h3>
 				<div class="flex gap-4 flex-wrap">
 					<MrButton variant="filled" class="!p-3 rounded-full">
 						<MrIcon icon="mdi-heart" class="text-current" />
@@ -172,7 +172,7 @@
 
 			<!-- Size variations with icons -->
 			<div class="space-y-2">
-				<h3 class="text-white text-lg font-medium">Size Variations</h3>
+				<h3 class=" text-lg font-medium">Size Variations</h3>
 				<div class="flex gap-4 items-center flex-wrap">
 					<MrButton size="xs">
 						<MrIcon icon="mdi-plus" class="mr-1" />


### PR DESCRIPTION
## Summary
- Add global default text colors that automatically switch based on theme (black for light mode, white for dark mode)
- Remove redundant `text-inverse` classes from basic text elements
- Replace hardcoded `text-white` with theme-aware defaults
- Preserve `text-primary` for semantic UI element colors

## Changes Made

### 1. Theme System Enhancement
- Added `--color-text-default` CSS variable to all themes:
  - Light theme: `#000000` (black)
  - Dark theme: `#ffffff` (white)  
  - Custom theme: `#2d3748` (dark gray)
- Applied global text color to body element: `color: var(--color-text-default)`

### 2. Component Cleanup
- **`src/routes/+page.svelte`**: Removed `text-inverse` from h1 and p elements
- **`src/routes/_test/goals-list/+page.svelte`**: Removed `text-inverse` and `text-white` classes
- **`src/routes/_test/mr-showcase/+page.svelte`**: Replaced all `text-white` with automatic inheritance

### 3. Preserved Semantic Colors
- Kept `text-primary`, `text-success`, `text-error`, etc. for UI elements
- Console components maintain their color-coded logging
- Icon colors remain explicit for visual hierarchy

## Benefits

✅ **Cleaner markup** - No need to add `text-inverse` to every text element  
✅ **Automatic theme switching** - Text color changes with theme automatically  
✅ **Better maintainability** - Less repetitive color class usage  
✅ **Preserved flexibility** - Semantic color classes still available when needed  
✅ **Build passes** - All components render correctly

## Test Plan
- [x] Verify build succeeds without errors
- [x] Check that text inherits correct colors in all themes
- [x] Ensure semantic color classes still work for special elements
- [x] Confirm console components maintain their color coding

🤖 Generated with [Claude Code](https://claude.ai/code)